### PR TITLE
Fail task when script exited with non-zero exit code

### DIFF
--- a/code.ts
+++ b/code.ts
@@ -16,7 +16,7 @@ async function run() {
     bash.arg(filename);
 
     try {
-        bash.exec();
+        await bash.exec();
         tl.setResult(tl.TaskResult.Succeeded, "Code works.");
     }
     catch (err) {


### PR DESCRIPTION
Currently this task doesn't fail if the script exits with a non-zero exit code.

Added `await` to `bash.exec()` so that it'll go into the `catch` block if task fails. Now it works as expected and fails the task if the script's exit code is not zero.